### PR TITLE
fix: add gitignore patterns for editor backups and temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,32 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# ===========================================
+# Editor backup/autosave files
+# ===========================================
+# Emacs
+\#*\#
+*~
+.\#*
+
+# Vim
+*.swp
+*.swo
+*~
+
+# ===========================================
+# Simulation temp/intermediate files
+# ===========================================
+# GROMACS backups
+\#*.xvg.*\#
+\#*.pdb.*\#
+\#*.gro.*\#
+\#*.trr.*\#
+\#*.xtc.*\#
+\#*.dat.*\#
+\#*.ndx.*\#
+
+# Temp directories (keep structure, ignore contents)
+**/temp/*
+!**/temp/.gitkeep


### PR DESCRIPTION
## Summary

Adds `.gitignore` patterns to prevent accidental commits of editor backup files and simulation temp outputs.

## Problem

The `run_data/run_2/temp/` directory has accumulated ~2300 files including:
- Emacs autosave files (`#filename#` pattern)
- Intermediate simulation outputs

These are editor artifacts and temp files that shouldn't be in version control.

## Changes

Added ignore patterns for:
- **Emacs**: `#*#`, `*~`, `.#*`
- **Vim**: `*.swp`, `*.swo`
- **GROMACS temp files**: `#*.xvg.*#`, `#*.pdb.*#`, etc.
- **Temp directories**: `**/temp/*` (with `.gitkeep` exception)

## Notes

This PR only prevents **future** commits of these files. The existing temp files would need to be cleaned up separately with:

```bash
git rm -r --cached abmelt_infer_pipeline/run_data/run_2/temp/
git commit -m "chore: remove temp files from tracking"
```

Happy to help with that cleanup if you'd like!